### PR TITLE
fix: PinController make field array error

### DIFF
--- a/src/pin-input-control/index.tsx
+++ b/src/pin-input-control/index.tsx
@@ -20,7 +20,7 @@ export const PinInputControl: FC<PinInputControlProps> = (
 ) => {
   const { name, label, pinAmount, stackProps, pinInputProps, ...rest } = props;
   const [field, , { setValue }] = useField(name);
-  const renderedPinInputFields = [...Array(pinAmount)].map((_noop, i) => (
+  const renderedPinInputFields = Array(pinAmount).fill(null).map((_noop, i) => (
     <PinInputField key={i} />
   ));
   function handleChange(value: string) {


### PR DESCRIPTION
The result of the previous compilation was

```javascript
  var renderedPinInputFields = [].concat(Array(pinAmount)).map(function (_noop, i) {
    return React__default.createElement(react.PinInputField, {
      key: i
    });
  });
```

I guess the rollup compilation conversion is the cause, but I don't know how to change it, here is another way to solve this error.

fix https://github.com/kgnugur/formik-chakra-ui/issues/93