### PR TITLE
Allow providing React.ReactNode for helperText

### DIFF
--- a/src/form-control/index.tsx
+++ b/src/form-control/index.tsx
@@ -44,8 +44,10 @@ export const FormControl: FC<BaseProps> = (props: BaseProps) => {
       {error && (
         <FormErrorMessage {...errorMessageProps}>{error}</FormErrorMessage>
       )}
-      {helperText && (
+      {helperText && typeof helperText === 'string' ? (
         <FormHelperText {...helperTextProps}>{helperText}</FormHelperText>
+      ) : (
+        helperText
       )}
     </ChakraFormControl>
   );

--- a/src/form-control/index.tsx
+++ b/src/form-control/index.tsx
@@ -15,7 +15,7 @@ export interface BaseProps extends FormControlProps {
   name: string;
   label?: string;
   labelProps?: FormLabelProps;
-  helperText?: string;
+  helperText?: React.ReactNode;
   helperTextProps?: HelpTextProps;
   errorMessageProps?: FormErrorMessageProps;
 }

--- a/src/form-control/index.tsx
+++ b/src/form-control/index.tsx
@@ -11,9 +11,9 @@ import {
 import { useField } from 'formik';
 import React, { FC } from 'react';
 
-export interface BaseProps extends FormControlProps {
+export interface BaseProps extends Omit<FormControlProps, 'label'> {
   name: string;
-  label?: string;
+  label?: React.ReactNode;
   labelProps?: FormLabelProps;
   helperText?: React.ReactNode;
   helperTextProps?: HelpTextProps;
@@ -35,10 +35,12 @@ export const FormControl: FC<BaseProps> = (props: BaseProps) => {
 
   return (
     <ChakraFormControl isInvalid={!!error && touched} {...rest}>
-      {label && (
+      {label && typeof label === 'string' ? (
         <FormLabel htmlFor={name} {...labelProps}>
           {label}
         </FormLabel>
+      ) : (
+        label
       )}
       {children}
       {error && (


### PR DESCRIPTION
Sometimes it can be useful to provide a `ReactNode` as Helper Text 