### PR TITLE
Add ability to customize slider filled track

### DIFF
--- a/src/slider-control/index.tsx
+++ b/src/slider-control/index.tsx
@@ -6,6 +6,7 @@ import {
   SliderThumbProps,
   SliderTrack,
   SliderTrackProps,
+  SliderInnerTrackProps,
 } from '@chakra-ui/react';
 import { useField, useFormikContext } from 'formik';
 import React, { FC } from 'react';
@@ -15,6 +16,7 @@ export type SliderControlProps = BaseProps & {
   sliderProps?: SliderProps;
   sliderTrackProps?: SliderTrackProps;
   sliderThumbProps?: SliderThumbProps;
+  sliderFilledTrackProps?: SliderInnerTrackProps;
 };
 
 export const SliderControl: FC<SliderControlProps> = (
@@ -26,6 +28,7 @@ export const SliderControl: FC<SliderControlProps> = (
     sliderProps,
     sliderTrackProps,
     sliderThumbProps,
+    sliderFilledTrackProps,
     ...rest
   } = props;
   const [field, , { setValue }] = useField(name);
@@ -51,7 +54,7 @@ export const SliderControl: FC<SliderControlProps> = (
         {...sliderProps}
       >
         <SliderTrack {...sliderTrackProps}>
-          <SliderFilledTrack />
+          <SliderFilledTrack {...sliderFilledTrackProps} />
         </SliderTrack>
         <SliderThumb {...sliderThumbProps} />
       </Slider>


### PR DESCRIPTION
```typescript
import {
  Slider,
  SliderFilledTrack,
  SliderProps,
  SliderThumb,
  SliderThumbProps,
  SliderTrack,
  SliderTrackProps,
  SliderInnerTrackProps,
} from '@chakra-ui/react';
import { useField, useFormikContext } from 'formik';
import React, { FC } from 'react';
import { BaseProps, FormControl } from '../form-control';

export type SliderControlProps = BaseProps & {
  sliderProps?: SliderProps;
  sliderTrackProps?: SliderTrackProps;
  sliderThumbProps?: SliderThumbProps;
  sliderFilledTrackProps?: SliderInnerTrackProps;
};

export const SliderControl: FC<SliderControlProps> = (
  props: SliderControlProps
) => {
  const {
    name,
    label,
    sliderProps,
    sliderTrackProps,
    sliderThumbProps,
    sliderFilledTrackProps,
    ...rest
  } = props;
  const [field, , { setValue }] = useField(name);
  const { isSubmitting } = useFormikContext();

  function handleChange(value: number) {
    setValue(value);
  }
  // Does not behave like expected, so we manually handle it.
  function handleBlur(e: React.FocusEvent<HTMLDivElement>) {
    (e.target as any).name = name;
    field.onBlur(e);
  }

  return (
    <FormControl name={name} label={label} {...rest}>
      <Slider
        {...field}
        id={name}
        onChange={handleChange}
        onBlur={handleBlur}
        isDisabled={isSubmitting}
        {...sliderProps}
      >
        <SliderTrack {...sliderTrackProps}>
          <SliderFilledTrack {...sliderFilledTrackProps} />
        </SliderTrack>
        <SliderThumb {...sliderThumbProps} />
      </Slider>
    </FormControl>
  );
};

export default SliderControl;
```

Adds sliderFilledTrackProps to the slider component so that you can give sliders a custom colour.